### PR TITLE
Upgrade to PHPUnit 11 (PHPUnit 7 EOL) to Match EGG PHP 8.2 (default)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: all install test
+
+all: install
+
+install:
+	composer install
+
+test:
+	composer test

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     "nesbot/carbon": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0"
+    "phpunit/phpunit": "^11.5"
   },
   "suggest": {
     "guzzlehttp/guzzle": "^6.3"
   },
   "scripts": {
-    "phpunit": "phpunit --verbose",
+    "phpunit": "phpunit --display-all-issues",
     "test": [
       "@phpunit"
     ]

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,10 +4,6 @@
         <testsuite name="all">
             <directory suffix="Test.php">tests/</directory>
         </testsuite>
-
-        <testsuite name="endpoints">
-            <directory suffix="Test.php">./tests/API/Endpoints/</directory>
-        </testsuite>
     </testsuites>
     <php>
         <ini name="max_execution_time" value="0"/>

--- a/tests/API/Endpoints/KeysEndpointTest.php
+++ b/tests/API/Endpoints/KeysEndpointTest.php
@@ -43,7 +43,7 @@ class KeysEndpointTest extends BaseTestCase
         $this->assertFalse($result);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/API/Endpoints/TokenEndpointTest.php
+++ b/tests/API/Endpoints/TokenEndpointTest.php
@@ -98,7 +98,7 @@ class TokenEndpointTest extends BaseTestCase
         $tokenEndpoint->create("123", "10", "MAD", "123.123.123.123");
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/API/Endpoints/TransactionEndpointTest.php
+++ b/tests/API/Endpoints/TransactionEndpointTest.php
@@ -105,7 +105,7 @@ class TransactionEndpointTest extends BaseTestCase
         $this->assertEquals($secondTransaction->getCreatedAt(), "2021-08-18 10:00:00");
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/API/FakeAPIService.php
+++ b/tests/API/FakeAPIService.php
@@ -8,6 +8,7 @@ use YouCan\Pay\API\Response;
 class FakeAPIService implements APIServiceInterface
 {
     public static $isSandboxMode = false;
+    private Response $response;
 
     /** @var FakeAPIAdapter */
     private $httpAdapter;


### PR DESCRIPTION
## QA Steps

* [ ] Open the egg PHP container: `egg c php`
* [ ] Go to the SDK directory: `cd /var/dev/youcan-payment-php-sdk`
* [ ] Run dependency install: `make install`
* [ ] Run the tests `make test`
* [ ] Verify all tests pass (green)